### PR TITLE
ML-399 Remove typedefs to fix compiler warnings

### DIFF
--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -6,6 +6,6 @@ EXPORT Bundle := MODULE(Std.BundleBase)
  EXPORT License := 'http://www.apache.org/licenses/LICENSE-2.0';
  EXPORT Copyright := 'Copyright (C) 2017 HPCC Systems';
  EXPORT DependsOn := ['ML_Core','PBblas'];
- EXPORT Version := '0.1';
+ EXPORT Version := '1.1';
  EXPORT PlatformVersion := '6.2.0';
 END;

--- a/libsvm/SVMPredict.ecl
+++ b/libsvm/SVMPredict.ecl
@@ -20,14 +20,14 @@ EXPORT DATASET(R8Entry) SVMPredict(Model ecl_model, DATASET(Node) ecl_nodes,
   #endif
     #ifndef ECL_SVM_NODE
     #define ECL_SVM_NODE
-    typedef struct __attribute__ ((__packed__))  Packed_SVM_Node {
+    struct __attribute__ ((__packed__))  Packed_SVM_Node {
       int indx;
       double value;
     };
   #endif
   #ifndef ECL_SVM_MODEL
   #define ECL_SVM_MODEL
-    typedef struct __attribute__ ((__packed__)) Packed_SVM_Model {
+    struct __attribute__ ((__packed__)) Packed_SVM_Model {
       unsigned short svm_type;
       unsigned short kernel_type;
       int degree;

--- a/libsvm/SVMTrain.ecl
+++ b/libsvm/SVMTrain.ecl
@@ -19,7 +19,7 @@ DATA svm_train_d(SVM_Parms prm,
   #endif
   #ifndef ECL_LIBSVM_TRAIN_PARAM
   #define ECL_LIBSVM_TRAIN_PARAM
-    typedef struct __attribute__ ((__packed__)) ecl_svm_parameter {
+    struct __attribute__ ((__packed__)) ecl_svm_parameter {
       unsigned short svm_type;
       unsigned short kernel_type;
       int degree;
@@ -37,7 +37,7 @@ DATA svm_train_d(SVM_Parms prm,
   #endif
   #ifndef ECL_SVM_PROBLEM
   #define ECL_SVM_PROBLEM
-    typedef struct __attribute__ ((__packed__)) ecl_svm_problem {
+    struct __attribute__ ((__packed__)) ecl_svm_problem {
       unsigned int elements;
       int entries;
       unsigned int features;
@@ -46,7 +46,7 @@ DATA svm_train_d(SVM_Parms prm,
     #endif
     #ifndef ECL_SVM_NODE
     #define ECL_SVM_NODE
-    typedef struct __attribute__ ((__packed__))  Packed_SVM_Node {
+    struct __attribute__ ((__packed__))  Packed_SVM_Node {
       int indx;
       double value;
     };


### PR DESCRIPTION
Signed-off-by: johnholt <john.d.holt@lexisnexisrisk.com>